### PR TITLE
Avoid `test` folder generation

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -189,6 +189,10 @@ after_bundle do
   environment 'config.action_mailer.default_url_options = { host: "http://localhost:3000" }', env: 'development'
   environment 'config.action_mailer.default_url_options = { host: "http://TODO_PUT_YOUR_DOMAIN_HERE" }', env: 'production'
 
+  # Get rid of `test` directory
+  #######################################
+  run 'rm -rf test'
+
   # Test config
   #######################################
   generate('rspec:install')


### PR DESCRIPTION
As per the [original issue](https://github.com/Naokimi/lewagon-rails-template-plus/issues/4) – this PR eliminates `test` directory as soon as the app is generated. I was hoping that defining :rspec as a default testing framework could help to avoid automatically created `test` directory, but it doesn't help in this regard unfortunately.