### PR TITLE
Specify factories directory

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -116,9 +116,10 @@ file 'README.md', markdown_file_content, force: true
 ########################################
 generators = <<~RUBY
   config.generators do |generate|
-    generate.test_framework :rspec
     generate.assets false
     generate.helper false
+    generate.test_framework :rspec
+    generate.fixture_replacement :factory_bot, dir: 'spec/support/factories'
   end
 RUBY
 


### PR DESCRIPTION
As per [original request](https://github.com/Naokimi/lewagon-rails-template-plus/issues/8) – this PR defines default factories directory as `spec/support/factories`